### PR TITLE
fix: use AccountPriceExterne by default on account creation

### DIFF
--- a/backend/api/account.go
+++ b/backend/api/account.go
@@ -88,7 +88,7 @@ func (s *Server) PostAccounts(c echo.Context) error {
 		cardId = *req.CardId
 	}
 
-	var priceRole = autogen.AccountPriceCeten
+	var priceRole = autogen.AccountPriceExterne
 	if req.PriceRole != nil {
 		priceRole = *req.PriceRole
 	}

--- a/backend/api/connectCard.go
+++ b/backend/api/connectCard.go
@@ -35,7 +35,7 @@ func (s *Server) ConnectCard(c echo.Context) error {
 				CardId:    autogen.OptionalString(param.CardId),
 				Id:        uuid.New(),
 				Role:      autogen.AccountStudent,
-				PriceRole: autogen.AccountPriceCeten,
+				PriceRole: autogen.AccountPriceExterne,
 				State:     autogen.AccountNotOnBoarded,
 			},
 		}


### PR DESCRIPTION
# Summary

Use `AccountPriceExterne` price role by default on account creation

---

<!-- If your pr is related to existing issue, please link them here with a closing keyword -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
### Related issues :
- Fixes #161 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please add the corresponding labels to your pull request -->
- [x] Bug fix (non-breaking change which fixes an issue)            <!-- bug -->
- [ ] New feature (non-breaking change which adds functionality)    <!-- enhancement -->
- [ ] Documentation (update or create documentation)                <!-- documentation -->
- [ ] CI/CD                                                         <!-- CI/CD -->
- [ ] Other
<!-- Don't forget to add the "breaking change" label ! -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  <!-- breaking change -->
