### PR TITLE
Remove gorilla/context

### DIFF
--- a/backend/api/impl.go
+++ b/backend/api/impl.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	gorillaContext "github.com/gorilla/context"
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -115,7 +114,6 @@ func (s *Server) Serve(c *config.Config) error {
 	onBoardStore := sessions.NewCookieStore([]byte(c.ApiConfig.AdminSessionSecret))
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			defer gorillaContext.Clear(c.Request())
 			c.Set("userStore", userStore)
 			c.Set("adminStore", adminStore)
 			c.Set("onBoardStore", onBoardStore)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.5.0
-	github.com/gorilla/context v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/joho/godotenv v1.5.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -70,8 +70,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
-github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
-github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=


### PR DESCRIPTION
# Summary

Remove useless call and associated useless dependency.

It appears that the Clear call only affects data set through gorillaContext.Set which we do not use. Indeed, that's the only call we make to gorilla/context and no dependencies seems to rely on it. (On top of that, its use is discouraged in favor of context.Context since go 1.7.).

---

<!-- If your pr is related to existing issue, please link them here with a closing keyword -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
### Related issues :
- None

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please add the corresponding labels to your pull request -->
- [ ] Bug fix (non-breaking change which fixes an issue)            <!-- bug -->
- [ ] New feature (non-breaking change which adds functionality)    <!-- enhancement -->
- [ ] Documentation (update or create documentation)                <!-- documentation -->
- [ ] CI/CD                                                         <!-- CI/CD -->
- [x] Other
<!-- Don't forget to add the "breaking change" label ! -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  <!-- breaking change -->
